### PR TITLE
Move contribution section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+## Contribution
+1. Fork it ( http://github.com/takahirom/PreLollipopTransition/fork )
+2. Create your feature branch (git checkout -b my-new-feature)
+3. Commit your changes (git commit -am 'Add some feature')
+4. Push to the branch (git push origin my-new-feature)
+5. Create new Pull Request

--- a/README.md
+++ b/README.md
@@ -125,13 +125,6 @@ https://www.flickr.com/photos/lukema/12499338274/in/photostream/
 DevBytes: Custom Activity Animations
 https://www.youtube.com/watch?v=CPxkoe2MraA
 
-## Contribution
-1. Fork it ( http://github.com/takahirom/PreLollipopTransition/fork )
-2. Create your feature branch (git checkout -b my-new-feature)
-3. Commit your changes (git commit -am 'Add some feature')
-4. Push to the branch (git push origin my-new-feature)
-5. Create new Pull Request
-
 ## License
 
 This project is released under the Apache License, Version 2.0.


### PR DESCRIPTION
Adding CONTRIBUTING.md shows how to contribute when users report issue or send pull request. Since this library has lots of users, you should move contribution section from README.
Here is detail [description](https://github.com/blog/1184-contributing-guidelines).

By the way, congratulations for 365 days contribution streak! (Actually, this is what I really want to say.)
