### PR TITLE
Rename packages to comply with standard naming convention

### DIFF
--- a/sample-app/src/androidTest/java/com/kogitune/prelollipoptransition/MainActivityTest.java
+++ b/sample-app/src/androidTest/java/com/kogitune/prelollipoptransition/MainActivityTest.java
@@ -23,7 +23,7 @@ import android.test.ActivityInstrumentationTestCase2;
 import android.view.KeyEvent;
 import android.widget.ImageView;
 
-import com.kogitune.activity_transition.core.TransitionAnimation;
+import com.kogitune.activitytransition.core.TransitionAnimation;
 import com.squareup.spoon.Spoon;
 
 import junit.framework.Assert;

--- a/sample-app/src/main/java/com/kogitune/prelollipoptransition/ListViewActivity.java
+++ b/sample-app/src/main/java/com/kogitune/prelollipoptransition/ListViewActivity.java
@@ -27,7 +27,7 @@ import android.widget.AdapterView.OnItemClickListener;
 import android.widget.BaseAdapter;
 import android.widget.ListView;
 
-import com.kogitune.activity_transition.ActivityTransitionLauncher;
+import com.kogitune.activitytransition.ActivityTransitionLauncher;
 
 public class ListViewActivity extends AppCompatActivity {
 

--- a/sample-app/src/main/java/com/kogitune/prelollipoptransition/MainActivity.java
+++ b/sample-app/src/main/java/com/kogitune/prelollipoptransition/MainActivity.java
@@ -25,7 +25,7 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Toast;
 
-import com.kogitune.activity_transition.ActivityTransitionLauncher;
+import com.kogitune.activitytransition.ActivityTransitionLauncher;
 import com.kogitune.prelollipoptransition.support_fragment.SupportStartFragment;
 
 

--- a/sample-app/src/main/java/com/kogitune/prelollipoptransition/SubActivity.java
+++ b/sample-app/src/main/java/com/kogitune/prelollipoptransition/SubActivity.java
@@ -20,8 +20,8 @@ package com.kogitune.prelollipoptransition;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
-import com.kogitune.activity_transition.ActivityTransition;
-import com.kogitune.activity_transition.ExitActivityTransition;
+import com.kogitune.activitytransition.ActivityTransition;
+import com.kogitune.activitytransition.ExitActivityTransition;
 
 
 public class SubActivity extends AppCompatActivity {

--- a/sample-app/src/main/java/com/kogitune/prelollipoptransition/SubActivity2.java
+++ b/sample-app/src/main/java/com/kogitune/prelollipoptransition/SubActivity2.java
@@ -23,8 +23,8 @@ import android.support.v7.app.AppCompatActivity;
 import android.view.animation.BounceInterpolator;
 import android.view.animation.OvershootInterpolator;
 
-import com.kogitune.activity_transition.ActivityTransition;
-import com.kogitune.activity_transition.ExitActivityTransition;
+import com.kogitune.activitytransition.ActivityTransition;
+import com.kogitune.activitytransition.ExitActivityTransition;
 
 
 public class SubActivity2 extends AppCompatActivity {

--- a/sample-app/src/main/java/com/kogitune/prelollipoptransition/fragment/EndFragment.java
+++ b/sample-app/src/main/java/com/kogitune/prelollipoptransition/fragment/EndFragment.java
@@ -23,8 +23,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.kogitune.activity_transition.fragment.ExitFragmentTransition;
-import com.kogitune.activity_transition.fragment.FragmentTransition;
+import com.kogitune.activitytransition.fragment.ExitFragmentTransition;
+import com.kogitune.activitytransition.fragment.FragmentTransition;
 import com.kogitune.prelollipoptransition.R;
 
 public class EndFragment extends Fragment {

--- a/sample-app/src/main/java/com/kogitune/prelollipoptransition/fragment/StartFragment.java
+++ b/sample-app/src/main/java/com/kogitune/prelollipoptransition/fragment/StartFragment.java
@@ -24,7 +24,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.kogitune.activity_transition.fragment.FragmentTransitionLauncher;
+import com.kogitune.activitytransition.fragment.FragmentTransitionLauncher;
 import com.kogitune.prelollipoptransition.R;
 
 public class StartFragment extends Fragment {

--- a/sample-app/src/main/java/com/kogitune/prelollipoptransition/support_fragment/SupportEndFragment.java
+++ b/sample-app/src/main/java/com/kogitune/prelollipoptransition/support_fragment/SupportEndFragment.java
@@ -24,8 +24,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.kogitune.activity_transition.fragment.ExitFragmentTransition;
-import com.kogitune.activity_transition.fragment.FragmentTransition;
+import com.kogitune.activitytransition.fragment.ExitFragmentTransition;
+import com.kogitune.activitytransition.fragment.FragmentTransition;
 import com.kogitune.prelollipoptransition.R;
 
 public class SupportEndFragment extends Fragment {

--- a/sample-app/src/main/java/com/kogitune/prelollipoptransition/support_fragment/SupportStartFragment.java
+++ b/sample-app/src/main/java/com/kogitune/prelollipoptransition/support_fragment/SupportStartFragment.java
@@ -23,7 +23,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.kogitune.activity_transition.fragment.FragmentTransitionLauncher;
+import com.kogitune.activitytransition.fragment.FragmentTransitionLauncher;
 import com.kogitune.prelollipoptransition.R;
 
 public class SupportStartFragment extends Fragment {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S00120 - “ Package names should comply with a naming convention”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S00120
Please let me know if you have any questions.
Ayman Abdelghany.
